### PR TITLE
Add User Profile Page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,9 @@
 import { AppShell, Container, Group, Title, Button, Menu } from '@mantine/core';
 import { useAuth0 } from '@auth0/auth0-react';
-import { IconLogout } from '@tabler/icons-react';
-import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { IconLogout, IconUser } from '@tabler/icons-react';
+import { BrowserRouter as Router, Routes, Route, Link, useNavigate } from 'react-router-dom';
 import { Home } from './pages/Home';
+import { Profile } from './pages/Profile';
 
 function App() {
   const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0();
@@ -46,6 +47,13 @@ function App() {
                     </Menu.Target>
                     <Menu.Dropdown>
                       <Menu.Item
+                        component={Link}
+                        to="/user/profile"
+                        leftSection={<IconUser size="1rem" />}
+                      >
+                        Profile
+                      </Menu.Item>
+                      <Menu.Item
                         onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}
                         leftSection={<IconLogout size="1rem" />}
                         color="red"
@@ -67,6 +75,7 @@ function App() {
         <AppShell.Main>
           <Routes>
             <Route path="/" element={<Home />} />
+            <Route path="/user/profile" element={<Profile />} />
           </Routes>
         </AppShell.Main>
       </AppShell>

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,0 +1,95 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import {
+  Container,
+  Title,
+  Paper,
+  Text,
+  Group,
+  Stack,
+  Avatar,
+  Divider,
+  Badge,
+  Card,
+  SimpleGrid
+} from '@mantine/core';
+
+export function Profile() {
+  const { user, isLoading } = useAuth0();
+
+  if (isLoading) {
+    return (
+      <Container size="md" py="xl">
+        <Text>Loading profile...</Text>
+      </Container>
+    );
+  }
+
+  if (!user) {
+    return (
+      <Container size="md" py="xl">
+        <Text>Please log in to view your profile.</Text>
+      </Container>
+    );
+  }
+
+  return (
+    <Container size="md" py="xl">
+      <Paper shadow="sm" p="xl" radius="md">
+        <Group align="flex-start" mb="xl">
+          <Avatar 
+            src={user.picture} 
+            size="xl" 
+            radius="md"
+            alt={user.name || 'Profile picture'}
+          />
+          <Stack gap="xs">
+            <Title order={2}>{user.name}</Title>
+            <Text size="sm" c="dimmed">{user.email}</Text>
+            {user.email_verified && (
+              <Badge color="green" variant="light">Email Verified</Badge>
+            )}
+          </Stack>
+        </Group>
+
+        <Divider my="lg" />
+
+        <SimpleGrid cols={1} spacing="md">
+          <Card withBorder padding="md">
+            <Text size="sm" fw={500} c="dimmed" mb="xs">Auth0 ID</Text>
+            <Text>{user.sub}</Text>
+          </Card>
+
+          {user.nickname && (
+            <Card withBorder padding="md">
+              <Text size="sm" fw={500} c="dimmed" mb="xs">Nickname</Text>
+              <Text>{user.nickname}</Text>
+            </Card>
+          )}
+
+          {user.locale && (
+            <Card withBorder padding="md">
+              <Text size="sm" fw={500} c="dimmed" mb="xs">Locale</Text>
+              <Text>{user.locale}</Text>
+            </Card>
+          )}
+
+          {user.updated_at && (
+            <Card withBorder padding="md">
+              <Text size="sm" fw={500} c="dimmed" mb="xs">Last Updated</Text>
+              <Text>{new Date(user.updated_at).toLocaleString()}</Text>
+            </Card>
+          )}
+        </SimpleGrid>
+
+        <Divider my="lg" label="Raw Profile Data" labelPosition="center" />
+
+        <Card withBorder padding="md">
+          <Text size="sm" fw={500} c="dimmed" mb="xs">Complete Profile JSON</Text>
+          <Text component="pre" style={{ whiteSpace: 'pre-wrap' }}>
+            {JSON.stringify(user, null, 2)}
+          </Text>
+        </Card>
+      </Paper>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Description
This PR adds a new user profile page that displays Auth0 user information in a well-structured and styled format.

## Changes
- Create Profile page component under `/user/profile`
- Add profile page to navigation menu
- Display Auth0 profile information including:
  * User picture and name
  * Email and verification status
  * Auth0 ID
  * Additional profile fields
  * Raw profile data for debugging
- Add loading and error states
- Style with Mantine components

## Testing
- Profile page is accessible at `/user/profile`
- Page shows loading state while fetching user data
- All Auth0 profile fields are displayed correctly
- Navigation menu includes Profile link
- Page is only accessible when authenticated

## Screenshots
N/A (Please test in review app)

## Type of Change
- [x] New feature (non-breaking change adding functionality)
- [x] UI/UX improvement

## Dependencies
No new dependencies added. Uses existing:
- Mantine UI components
- Auth0 React SDK
- React Router

## Deployment Notes
No special deployment steps required. Uses existing Auth0 configuration.