### PR TITLE
Fix: Add tenant context to project creation flow

### DIFF
--- a/client/src/hooks/useProjectSubmission.ts
+++ b/client/src/hooks/useProjectSubmission.ts
@@ -12,14 +12,15 @@ import { createProjectPayload } from '../utils/project/transforms';
 
 /**
  * Project submission hook
+ * @param tenantId - ID of the tenant where the project will be created
  */
-export function useProjectSubmission() {
+export function useProjectSubmission(tenantId: string) {
   const navigate = useNavigate();
-  const { createProject } = useCreateProject();
+  const { createProject } = useCreateProject(tenantId);
 
   const submit = useCallback(async (data: ProjectFormData) => {
     try {
-      const payload = createProjectPayload(data, 'default');
+      const payload = createProjectPayload(data, tenantId);
       const project = await createProject(payload);
       
       showSuccessNotification();
@@ -30,7 +31,7 @@ export function useProjectSubmission() {
       handleProjectError(error);
       return null;
     }
-  }, [createProject, navigate]);
+  }, [createProject, navigate, tenantId]);
 
   return {
     submit

--- a/client/src/hooks/useProjectWizard.ts
+++ b/client/src/hooks/useProjectWizard.ts
@@ -91,7 +91,7 @@ export function useProjectWizard({
   } = useWizardState<ProjectFormData>(STEPS);
 
   const { validateStep } = useProjectValidation();
-  const { submit: submitProject } = useProjectSubmission();
+  const { submit: submitProject } = useProjectSubmission(tenantId);
 
   // Validate current step when data changes
   useEffect(() => {


### PR DESCRIPTION
This PR fixes issue #145 by properly passing the tenant context through the project creation flow.

Changes:
- Update useProjectSubmission to accept tenantId parameter
- Pass tenantId through useProjectWizard to submission hook
- Ensure tenant context is included in project payload

Implementation:
- Uses existing tenant context and hooks
- Follows DRY principles by reusing components
- Maintains consistent error handling patterns
- No new testing infrastructure needed

Tested:
- Build passes successfully
- TypeScript compilation successful
- No new dependencies added